### PR TITLE
Make sure CallKit session is ended on fail

### DIFF
--- a/ios/RNTwilioVoice/RNTwilioVoice.m
+++ b/ios/RNTwilioVoice/RNTwilioVoice.m
@@ -360,9 +360,8 @@ RCT_REMAP_METHOD(getActiveCall,
   }
   [self sendEventWithName:@"connectionDidDisconnect" body:params];
 
-  if (self.call.state == TVOCallStateConnected) {
-    [self performEndCallActionWithUUID:call.uuid];
-  }
+  [self performEndCallActionWithUUID:call.uuid];
+
   self.call = nil;
 }
 


### PR DESCRIPTION
The CallKit session isn't ended when making an outbound call fails. 